### PR TITLE
Translate zh-tw localization for Archivum Messelina

### DIFF
--- a/.codex/darktide_zh_tw_termbase.json
+++ b/.codex/darktide_zh_tw_termbase.json
@@ -1,0 +1,24 @@
+{
+  "terms": {
+    "AFK": "AFK",
+    "Archivum Messelina": "Archivum Messelina",
+    "Penance": "苦修",
+    "penances": "苦修",
+    "filter": "篩選",
+    "search": "搜尋",
+    "favourites": "收藏",
+    "check": "檢查",
+    "Block Check Limit": "阻擋檢查上限"
+  },
+  "style": {
+    "locale": "zh-tw",
+    "ui_tone": "natural, concise Traditional Chinese for Darktide mod settings",
+    "spacing": "Use spaces around retained Latin abbreviations such as AFK when embedded in Chinese sentences.",
+    "punctuation": "Use Traditional Chinese punctuation for full UI descriptions."
+  },
+  "source_priority": [
+    "Referneces/Translation.md",
+    "en localization strings"
+  ],
+  "last_updated": "2026-07-04T00:00:00+08:00"
+}

--- a/.codex/darktide_zh_tw_translation_progress.json
+++ b/.codex/darktide_zh_tw_translation_progress.json
@@ -1,0 +1,65 @@
+{
+  "current": {
+    "directory": "Archivum Messelina",
+    "base_branch": "origin/feature/Add-Archivum-Messelina",
+    "work_branch": "origin/feature/Add-Archivum-Messelina/codex",
+    "file": "Warhammer 40,000 DARKTIDE/mods/Archivum Messelina/scripts/mods/Archivum Messelina/Archivum Messelina_localization.lua",
+    "key": null,
+    "status": "file_completed"
+  },
+  "directories": {
+    "afk": {
+      "status": "pr_opened",
+      "base_branch": "origin/feature/Add-AFK",
+      "work_branch": "origin/feature/Add-AFK/codex",
+      "completed_files": [
+        "Warhammer 40,000 DARKTIDE/mods/afk/scripts/mods/afk/afk_localization.lua"
+      ],
+      "completed_keys": {
+        "Warhammer 40,000 DARKTIDE/mods/afk/scripts/mods/afk/afk_localization.lua": [
+          "mod_name",
+          "mod_description",
+          "block_check_limit",
+          "block_check_limit_description"
+        ]
+      },
+      "blocked_keys": {},
+      "last_file": "Warhammer 40,000 DARKTIDE/mods/afk/scripts/mods/afk/afk_localization.lua",
+      "last_key": "block_check_limit_description",
+      "commit": "0d6fd497d75e28e517911249a66fb5965dfb373b",
+      "pushed": true,
+      "pr_url": "https://github.com/SyuanTsai/Warhammer-40-000-DARKTIDE-Mods/pull/3",
+      "pr_number": 3
+    },
+    "Archivum Messelina": {
+      "status": "translated",
+      "base_branch": "origin/feature/Add-Archivum-Messelina",
+      "work_branch": "origin/feature/Add-Archivum-Messelina/codex",
+      "completed_files": [
+        "Warhammer 40,000 DARKTIDE/mods/Archivum Messelina/scripts/mods/Archivum Messelina/Archivum Messelina_localization.lua"
+      ],
+      "completed_keys": {
+        "Warhammer 40,000 DARKTIDE/mods/Archivum Messelina/scripts/mods/Archivum Messelina/Archivum Messelina_localization.lua": [
+          "loc_AM_filter_unearnt",
+          "loc_AM_filter_completed",
+          "loc_AM_filter_unclaimed",
+          "loc_AM_no_filter",
+          "mod_name",
+          "mod_description",
+          "max_favourites",
+          "search"
+        ]
+      },
+      "blocked_keys": {},
+      "last_file": "Warhammer 40,000 DARKTIDE/mods/Archivum Messelina/scripts/mods/Archivum Messelina/Archivum Messelina_localization.lua",
+      "last_key": "search",
+      "commit": null,
+      "pushed": false,
+      "pr_url": null,
+      "pr_number": null
+    }
+  },
+  "completed_directories": [
+    "afk"
+  ]
+}

--- a/.codex/darktide_zh_tw_translation_progress.json
+++ b/.codex/darktide_zh_tw_translation_progress.json
@@ -1,11 +1,11 @@
 {
   "current": {
-    "directory": "Archivum Messelina",
-    "base_branch": "origin/feature/Add-Archivum-Messelina",
-    "work_branch": "origin/feature/Add-Archivum-Messelina/codex",
-    "file": "Warhammer 40,000 DARKTIDE/mods/Archivum Messelina/scripts/mods/Archivum Messelina/Archivum Messelina_localization.lua",
+    "directory": "AUPM",
+    "base_branch": "origin/feature/Add-AUPM",
+    "work_branch": "origin/feature/Add-AUPM/codex",
+    "file": null,
     "key": null,
-    "status": "file_completed"
+    "status": "pending"
   },
   "directories": {
     "afk": {
@@ -32,7 +32,7 @@
       "pr_number": 3
     },
     "Archivum Messelina": {
-      "status": "translated",
+      "status": "pr_opened",
       "base_branch": "origin/feature/Add-Archivum-Messelina",
       "work_branch": "origin/feature/Add-Archivum-Messelina/codex",
       "completed_files": [
@@ -53,13 +53,14 @@
       "blocked_keys": {},
       "last_file": "Warhammer 40,000 DARKTIDE/mods/Archivum Messelina/scripts/mods/Archivum Messelina/Archivum Messelina_localization.lua",
       "last_key": "search",
-      "commit": null,
-      "pushed": false,
-      "pr_url": null,
-      "pr_number": null
+      "commit": "cfbd9e010bbd2bf5de8396d78496b61a584c4d30",
+      "pushed": true,
+      "pr_url": "https://github.com/SyuanTsai/Warhammer-40-000-DARKTIDE-Mods/pull/4",
+      "pr_number": 4
     }
   },
   "completed_directories": [
-    "afk"
+    "afk",
+    "Archivum Messelina"
   ]
 }

--- a/Warhammer 40,000 DARKTIDE/mods/Archivum Messelina/scripts/mods/Archivum Messelina/Archivum Messelina_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/Archivum Messelina/scripts/mods/Archivum Messelina/Archivum Messelina_localization.lua
@@ -6,18 +6,18 @@ mod:add_global_localize_strings({
 		en = "Filtering by incomplete penances",
 		["zh-cn"] = "按未完成苦修筛选",
 		ru = "Фильтрация по незавершённым Искуплениям",
-		["zh-tw"] = "根據未完成苦修篩選",
+		["zh-tw"] = "依未完成苦修篩選",
 	},
 	loc_AM_filter_completed = {
 		en = "Filtering by completed penances",
 		["zh-cn"] = "按已完成苦修筛选",
 		ru = "Фильтрация по завершённым Искуплениям",
-		["zh-tw"] = "根據已完成苦修篩選",
+		["zh-tw"] = "依已完成苦修篩選",
 	},
 	loc_AM_filter_unclaimed = {
 		en = "Filtering by unclaimed penances",
 		["zh-cn"] = "按未领取苦修筛选",
-		["zh-tw"] = "根據未領取苦修篩選",
+		["zh-tw"] = "依未領取苦修篩選",
 		ru = "Фильтрация по незабранным Искуплениям",
 	},
 	loc_AM_no_filter = {
@@ -34,18 +34,18 @@ return {
 		en = "Archivum Messelina",
 		["zh-cn"] = "苦修筛选 - 梅塞利纳档案馆",
 		ru = "Архивум Месселина",
-		["zh-tw"] = "苦修篩選 - 梅塞利納檔案館",
+		["zh-tw"] = "Archivum Messelina",
 	},
 	mod_description = {
 		en = "Archivum Messelina will allow you to filter/search your penances",
 		["zh-cn"] = "梅塞利纳档案馆 - 允许你筛选/搜索苦修",
 		ru = "Archivum Messelina - позволит вам фильтровать/искать ваши Искупления",
-		["zh-tw"] = "梅塞利納檔案館 - 允許你篩選/搜尋你的苦修",
+		["zh-tw"] = "Archivum Messelina 可讓你篩選／搜尋苦修。",
 	},
 	max_favourites = {
 		en = "Maximum number of penance favourites",
 		["zh-cn"] = "苦修最多追踪数量",
-		["zh-tw"] = "最多可追蹤的苦修數量",
+		["zh-tw"] = "苦修收藏上限",
 		ru = "Максимальное количество избранных Искуплений"
 	},
 	search = {


### PR DESCRIPTION
## Summary
- Correct zh-tw localization for Archivum Messelina settings
- Keep terminology aligned with the zh-tw termbase
- Carry forward local Codex translation progress

## Checks
- Verified zh-tw entries are non-empty
- Validated progress and termbase JSON
- Reviewed diff scope before commit