### PR TITLE
Translate zh-tw localization for AUPM

### DIFF
--- a/.codex/darktide_zh_tw_termbase.json
+++ b/.codex/darktide_zh_tw_termbase.json
@@ -1,0 +1,28 @@
+{
+  "terms": {
+    "AFK": "AFK",
+    "Archivum Messelina": "Archivum Messelina",
+    "Penance": "苦修",
+    "penances": "苦修",
+    "filter": "篩選",
+    "search": "搜尋",
+    "favourites": "收藏",
+    "check": "檢查",
+    "custom development": "客製開發",
+    "data": "資料",
+    "horizontal offset": "水平偏移",
+    "vertical offset": "垂直偏移",
+    "Block Check Limit": "阻擋檢查上限"
+  },
+  "style": {
+    "locale": "zh-tw",
+    "ui_tone": "natural, concise Traditional Chinese for Darktide mod settings",
+    "spacing": "Use spaces around retained Latin abbreviations such as AFK when embedded in Chinese sentences.",
+    "punctuation": "Use Traditional Chinese punctuation for full UI descriptions."
+  },
+  "source_priority": [
+    "Referneces/Translation.md",
+    "en localization strings"
+  ],
+  "last_updated": "2026-07-04T00:00:00+08:00"
+}

--- a/.codex/darktide_zh_tw_translation_progress.json
+++ b/.codex/darktide_zh_tw_translation_progress.json
@@ -1,0 +1,91 @@
+{
+  "current": {
+    "directory": "AUPM",
+    "base_branch": "origin/feature/Add-AUPM",
+    "work_branch": "origin/feature/Add-AUPM/codex",
+    "file": "Warhammer 40,000 DARKTIDE/mods/AUPM/scripts/mods/AUPM/AUPM_localization.lua",
+    "key": null,
+    "status": "file_completed"
+  },
+  "directories": {
+    "afk": {
+      "status": "pr_opened",
+      "base_branch": "origin/feature/Add-AFK",
+      "work_branch": "origin/feature/Add-AFK/codex",
+      "completed_files": [
+        "Warhammer 40,000 DARKTIDE/mods/afk/scripts/mods/afk/afk_localization.lua"
+      ],
+      "completed_keys": {
+        "Warhammer 40,000 DARKTIDE/mods/afk/scripts/mods/afk/afk_localization.lua": [
+          "mod_name",
+          "mod_description",
+          "block_check_limit",
+          "block_check_limit_description"
+        ]
+      },
+      "blocked_keys": {},
+      "last_file": "Warhammer 40,000 DARKTIDE/mods/afk/scripts/mods/afk/afk_localization.lua",
+      "last_key": "block_check_limit_description",
+      "commit": "0d6fd497d75e28e517911249a66fb5965dfb373b",
+      "pushed": true,
+      "pr_url": "https://github.com/SyuanTsai/Warhammer-40-000-DARKTIDE-Mods/pull/3",
+      "pr_number": 3
+    },
+    "Archivum Messelina": {
+      "status": "pr_opened",
+      "base_branch": "origin/feature/Add-Archivum-Messelina",
+      "work_branch": "origin/feature/Add-Archivum-Messelina/codex",
+      "completed_files": [
+        "Warhammer 40,000 DARKTIDE/mods/Archivum Messelina/scripts/mods/Archivum Messelina/Archivum Messelina_localization.lua"
+      ],
+      "completed_keys": {
+        "Warhammer 40,000 DARKTIDE/mods/Archivum Messelina/scripts/mods/Archivum Messelina/Archivum Messelina_localization.lua": [
+          "loc_AM_filter_unearnt",
+          "loc_AM_filter_completed",
+          "loc_AM_filter_unclaimed",
+          "loc_AM_no_filter",
+          "mod_name",
+          "mod_description",
+          "max_favourites",
+          "search"
+        ]
+      },
+      "blocked_keys": {},
+      "last_file": "Warhammer 40,000 DARKTIDE/mods/Archivum Messelina/scripts/mods/Archivum Messelina/Archivum Messelina_localization.lua",
+      "last_key": "search",
+      "commit": "cfbd9e010bbd2bf5de8396d78496b61a584c4d30",
+      "pushed": true,
+      "pr_url": "https://github.com/SyuanTsai/Warhammer-40-000-DARKTIDE-Mods/pull/4",
+      "pr_number": 4
+    },
+    "AUPM": {
+      "status": "translated",
+      "base_branch": "origin/feature/Add-AUPM",
+      "work_branch": "origin/feature/Add-AUPM/codex",
+      "completed_files": [
+        "Warhammer 40,000 DARKTIDE/mods/AUPM/scripts/mods/AUPM/AUPM_localization.lua"
+      ],
+      "completed_keys": {
+        "Warhammer 40,000 DARKTIDE/mods/AUPM/scripts/mods/AUPM/AUPM_localization.lua": [
+          "mod_name",
+          "mod_description",
+          "personal_x_offset",
+          "personal_y_offset",
+          "team_x_offset",
+          "team_y_offset"
+        ]
+      },
+      "blocked_keys": {},
+      "last_file": "Warhammer 40,000 DARKTIDE/mods/AUPM/scripts/mods/AUPM/AUPM_localization.lua",
+      "last_key": "team_y_offset",
+      "commit": null,
+      "pushed": false,
+      "pr_url": null,
+      "pr_number": null
+    }
+  },
+  "completed_directories": [
+    "afk",
+    "Archivum Messelina"
+  ]
+}

--- a/.codex/darktide_zh_tw_translation_progress.json
+++ b/.codex/darktide_zh_tw_translation_progress.json
@@ -1,11 +1,11 @@
 {
   "current": {
-    "directory": "AUPM",
-    "base_branch": "origin/feature/Add-AUPM",
-    "work_branch": "origin/feature/Add-AUPM/codex",
-    "file": "Warhammer 40,000 DARKTIDE/mods/AUPM/scripts/mods/AUPM/AUPM_localization.lua",
+    "directory": "AuspexHelper",
+    "base_branch": "origin/feature/Add-AuspexHelper",
+    "work_branch": "origin/feature/Add-AuspexHelper/codex",
+    "file": null,
     "key": null,
-    "status": "file_completed"
+    "status": "pending"
   },
   "directories": {
     "afk": {
@@ -59,7 +59,7 @@
       "pr_number": 4
     },
     "AUPM": {
-      "status": "translated",
+      "status": "pr_opened",
       "base_branch": "origin/feature/Add-AUPM",
       "work_branch": "origin/feature/Add-AUPM/codex",
       "completed_files": [
@@ -78,14 +78,15 @@
       "blocked_keys": {},
       "last_file": "Warhammer 40,000 DARKTIDE/mods/AUPM/scripts/mods/AUPM/AUPM_localization.lua",
       "last_key": "team_y_offset",
-      "commit": null,
-      "pushed": false,
-      "pr_url": null,
-      "pr_number": null
+      "commit": "04ad2d5b4eaa5fc7442192d5ebe01a6746612d27",
+      "pushed": true,
+      "pr_url": "https://github.com/SyuanTsai/Warhammer-40-000-DARKTIDE-Mods/pull/5",
+      "pr_number": 5
     }
   },
   "completed_directories": [
     "afk",
-    "Archivum Messelina"
+    "Archivum Messelina",
+    "AUPM"
   ]
 }

--- a/Warhammer 40,000 DARKTIDE/mods/AUPM/scripts/mods/AUPM/AUPM_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/AUPM/scripts/mods/AUPM/AUPM_localization.lua
@@ -5,7 +5,7 @@ return {
 	},
 	mod_description = {
 		en = "玩家技能次数数据显示 - 定制开发：deluxghost",
-		["zh-tw"] = "玩家技能次數數據顯示 - 定制開發：deluxghost",
+		["zh-tw"] = "玩家技能次數資料顯示 - 客製開發：deluxghost",
 	},
 	personal_x_offset = {
 		en = "个人面板水平偏移（左负右正）",


### PR DESCRIPTION
## Summary
- Correct zh-tw localization wording for AUPM settings
- Use Taiwan wording for data/custom development phrasing
- Carry forward local Codex translation progress

## Checks
- Verified zh-tw entries are non-empty
- Validated progress and termbase JSON
- Reviewed diff scope before commit

Note: this file's en source strings are Simplified Chinese, so updates were made only from the en field content.