### PR TITLE
[codex] Translate zh-tw localization for CharacterGrid

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/CharacterGrid/scripts/mods/CharacterGrid/CharacterGrid_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/CharacterGrid/scripts/mods/CharacterGrid/CharacterGrid_localization.lua
@@ -9,11 +9,11 @@ return {
 		en = "Make the character selection screen better",
 		ru = "CharacterGrid - Улучшите экран выбора персонажей.",
 		["zh-cn"] = "优化角色选择界面",
-		["zh-tw"] = "改善角色選擇畫面",
+		["zh-tw"] = "讓角色選擇畫面更好用",
 	},
 	character_count = {
 		en = "Number of characters to display in grid",
 		ru = "Количество персонажей для отображения в сетке",
-		["zh-tw"] = "網格中顯示的角色數量",
+		["zh-tw"] = "要在網格中顯示的角色數量",
 	}
 }

--- a/Warhammer 40,000 DARKTIDE/mods/CharacterGrid/scripts/mods/CharacterGrid/CharacterGrid_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/CharacterGrid/scripts/mods/CharacterGrid/CharacterGrid_localization.lua
@@ -3,13 +3,13 @@ return {
 		en = "CharacterGrid",
 		ru = "Сетка персонажей",
 		["zh-cn"] = "角色选择重新排序",
-		["zh-tw"] = "角色選擇重新排序",
+		["zh-tw"] = "角色網格",
 	},
 	mod_description = {
 		en = "Make the character selection screen better",
 		ru = "CharacterGrid - Улучшите экран выбора персонажей.",
 		["zh-cn"] = "优化角色选择界面",
-		["zh-tw"] = "優化角色選擇介面",
+		["zh-tw"] = "改善角色選擇畫面",
 	},
 	character_count = {
 		en = "Number of characters to display in grid",


### PR DESCRIPTION
Corrects CharacterGrid zh-tw localization from the English source.\n\nValidation:\n- Confirmed 3 localization keys have non-empty zh-tw values.\n- Confirmed no format placeholders are present/missing.\n- Confirmed the commit changes only CharacterGrid_localization.lua.\n- Lua CLI/luac were unavailable, so no Lua compile check was run.