### PR TITLE
[codex] Translate zh-tw localization for ChatBlock

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/ChatBlock/scripts/mods/ChatBlock/ChatBlock_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/ChatBlock/scripts/mods/ChatBlock/ChatBlock_localization.lua
@@ -3,13 +3,13 @@ return {
 		en = "Chat Block",
 		ru = "Чат Блок",
 		["zh-cn"] = "聊天自动格挡",
-		["zh-tw"] = "聊天格擋",
+		["zh-tw"] = "聊天自動格擋",
 	},
 	mod_description = {
 		en = "Automatically hold block while chatting, opening the Steam overlay, or while the game is not focussed",
 		["zh-cn"] = "在打开聊天、打开 Steam 游戏内界面或者切换到其他窗口时自动格挡",
 		ru =
 		"Chat Block - Автоматически удерживается блок во время использования чата, при открытии оверлея Steam или когда игра не находится в фокусе.",
-		["zh-tw"] = "聊天、開啟 Steam 內嵌介面，或遊戲不在焦點時自動維持格擋",
+		["zh-tw"] = "聊天、開啟 Steam 內嵌介面，或焦點不在遊戲視窗時自動維持格擋",
 	},
 }

--- a/Warhammer 40,000 DARKTIDE/mods/ChatBlock/scripts/mods/ChatBlock/ChatBlock_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/ChatBlock/scripts/mods/ChatBlock/ChatBlock_localization.lua
@@ -3,13 +3,13 @@ return {
 		en = "Chat Block",
 		ru = "Чат Блок",
 		["zh-cn"] = "聊天自动格挡",
-		["zh-tw"] = "聊天自動格擋",
+		["zh-tw"] = "聊天格擋",
 	},
 	mod_description = {
 		en = "Automatically hold block while chatting, opening the Steam overlay, or while the game is not focussed",
 		["zh-cn"] = "在打开聊天、打开 Steam 游戏内界面或者切换到其他窗口时自动格挡",
 		ru =
 		"Chat Block - Автоматически удерживается блок во время использования чата, при открытии оверлея Steam или когда игра не находится в фокусе.",
-		["zh-tw"] = "在打開聊天、打開 Steam 遊戲內界面或者切換到其他視窗時自動格擋",
+		["zh-tw"] = "聊天、開啟 Steam 內嵌介面，或遊戲不在焦點時自動維持格擋",
 	},
 }


### PR DESCRIPTION
Corrects ChatBlock zh-tw localization from the English source.\n\nValidation:\n- Confirmed 2 localization keys have non-empty zh-tw values.\n- Confirmed no format placeholders are present/missing.\n- Confirmed the commit changes only ChatBlock_localization.lua.\n- Lua CLI/luac were unavailable, so no Lua compile check was run.