### PR TITLE
[codex] Translate zh-tw localization for Decode_Helper

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/Decode_Helper/scripts/mods/Decode_Helper/Decode_Helper_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/Decode_Helper/scripts/mods/Decode_Helper/Decode_Helper_localization.lua
@@ -1,27 +1,30 @@
 return {
 	mod_name = {
 		en = "Decode Helper",
-		["zh-tw"] = "解碼助手",
+		["zh-tw"] = "解碼輔助",
 	},
 	mod_description = {
 		en = "Show upcoming target symbols when decoding.",
-		["zh-tw"] = "在解碼時顯示即將出現的目標符號。",
+		["zh-tw"] = "解碼時顯示接下來的目標符號。",
 	},
 	highlight_opacity = {
 		en = "Highlight Opacity",
-		["zh-tw"] = "高亮透明度",
+		["zh-tw"] = "醒目提示不透明度",
 	},
 	reveal_count = {
 		en = "Amount of Revealed Rows",
-		["zh-tw"] = "顯示的行數",
+		["zh-tw"] = "顯示列數",
 	},
 	num_1 = {
 		en = "1",
+		["zh-tw"] = "1",
 	},
 	num_2 = {
 		en = "2",
+		["zh-tw"] = "2",
 	},
 	num_3 = {
 		en = "3",
+		["zh-tw"] = "3",
 	},
 }


### PR DESCRIPTION
## Summary
- Correct zh-tw localization for Decode_Helper from en source strings
- Add missing zh-tw numeric options

## Validation
- Checked 7 en entries and 7 zh-tw entries
- Confirmed no empty zh-tw values
- Confirmed PR diff contains only Decode_Helper_localization.lua