### PR TITLE
[codex] Translate zh-tw localization for DecodeMinigameSolver

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/DecodeMinigameSolver/scripts/DecodeMinigameSolver_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/DecodeMinigameSolver/scripts/DecodeMinigameSolver_localization.lua
@@ -11,18 +11,18 @@ return {
   mod_name =
   {
     en = "Decode Minigame Solver",
-    ["zh-tw"] = "自動解碼",
+    ["zh-tw"] = "解碼小遊戲解題器",
   },
   mod_description =
   {
     en = "Passes the Decode Symbol Minigame automatically",
-    ["zh-tw"] = "自動解碼小遊戲",
+    ["zh-tw"] = "自動通過解碼符號小遊戲",
     ["zh-cn"] = "自动通过解码符号小游戏",
     ru = "Автоматически проходит мини-игру с символами декодирования",
   },
   [SettingNames.EnableMod] = {
     en = "Enable",
-    ["zh-tw"] = "啟動",
+    ["zh-tw"] = "啟用",
     ["zh-cn"] = "启用",
     ru = "Включить",
   },
@@ -34,19 +34,19 @@ return {
   },
   [SettingNames.InteractCooldownTooltip] = {
     en = "Wait time between interactions in milliseconds. Default: 150",
-    ["zh-tw"] = "互動冷卻時間為毫秒 預設值為150",
+    ["zh-tw"] = "互動之間的等待時間，單位為毫秒。預設值：150",
     ["zh-cn"] = "两次交互之间的等待时间（毫秒）。默认值：150",
     ru = "Время ожидания между взаимодействиями в миллисекундах. По умолчанию: 150",
   },
   [SettingNames.TargetPrecision] = {
     en = "Target Precision",
-    ["zh-tw"] = "目標精確度",
+    ["zh-tw"] = "目標精準度",
     ["zh-cn"] = "目标精度",
     ru = "Точность цели",
   },
   [SettingNames.TargetPrecisionTooltip] = {
     en = "The bigger the value, the smaller the detection window when the cursor is positioned on the symbol. Default: 4",
-    ["zh-tw"] = "當指標定位在符號上時 數值越大 偵測框越小 預設值為4",
+    ["zh-tw"] = "數值越大，游標位於符號上時的偵測範圍越小。預設值：4",
     ["zh-cn"] = "数值越大，当光标定位在符号上时，检测窗口越小。默认值：4",
     ru = "Чем больше значение, тем меньше окно обнаружения, когда курсор находится на символе. По умолчанию: 4",
   },


### PR DESCRIPTION
## Summary
- Correct zh-tw localization for DecodeMinigameSolver from en source strings
- Improve UI wording for cooldown and precision settings

## Validation
- Checked 7 en entries and 7 zh-tw entries
- Confirmed no empty zh-tw values
- Confirmed PR diff contains only DecodeMinigameSolver_localization.lua