### PR TITLE
[codex] Translate zh-tw localization for DefaultToHighestBlessingTier

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/DefaultToHighestBlessingTier/scripts/mods/DefaultToHighestBlessingTier/DefaultToHighestBlessingTier_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/DefaultToHighestBlessingTier/scripts/mods/DefaultToHighestBlessingTier/DefaultToHighestBlessingTier_localization.lua
@@ -3,12 +3,12 @@ return {
 		en = "Default To Highest Blessing Tier",
 		["zh-cn"] = "默认最高祝福等级",
 		ru = "Благословения высшего уровня по умолчанию",
-		["zh-tw"] = "預設最高祝福等級",
+		["zh-tw"] = "預設為最高祝福等級",
 	},
 	mod_description = {
 		en = "Automatically switch to the highest unlocked blessing tier in Re-Bless page.",
 		["zh-cn"] = "在重新祝福页面，自动切换到已解锁的最高祝福等级。",
 		ru = "Default To Highest Blessing Tier - Автоматически переключает на наивысший разблокированный уровень благословения на странице смены благословений.",
-		["zh-tw"] = "在重新祝福頁面，自動切換到已解鎖的最高祝福等級。",
+		["zh-tw"] = "在重新祝福頁面中，自動切換至已解鎖的最高祝福等級。",
 	},
 }


### PR DESCRIPTION
## Summary
- Correct zh-tw localization for DefaultToHighestBlessingTier from en source strings
- Polish wording for the Re-Bless page behavior

## Validation
- Checked 2 en entries and 2 zh-tw entries
- Confirmed no empty zh-tw values
- Confirmed PR diff contains only DefaultToHighestBlessingTier_localization.lua