### PR TITLE
[codex] Translate zh-tw localization for DisplayPing

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/DisplayPing/scripts/DisplayPing_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/DisplayPing/scripts/DisplayPing_localization.lua
@@ -15,7 +15,7 @@ local localizations = {
   mod_description = {
     en = "Displays your current ping",
     ru = "Отображает ваш текущий пинг",
-    ["zh-tw"] = "顯示當前延遲",
+    ["zh-tw"] = "顯示目前的延遲",
   },
   [SettingNames.EnableMod] = {
     en = "Enable",
@@ -26,19 +26,19 @@ local localizations = {
   [SettingNames.TacticalOverlayOnly] = {
     en = "Show only in tactical overlay",
     ["zh-cn"] = "仅在Tab页面显示",
-    ["zh-tw"] = "僅在Tab頁面顯示",
+    ["zh-tw"] = "僅在戰術覆蓋介面顯示",
     ru = "Показывать только в тактическом оверлее",
   },
   [SettingNames.HideInLobby] = {
     en = "Hide while in Mourningstar",
     ["zh-cn"] = "处于大厅时隐藏延迟信息",
-    ["zh-tw"] = "在大廳時隱藏延遲資訊",
+    ["zh-tw"] = "位於哀星號時隱藏延遲資訊",
     ru = "Спрятывать в лобби",
   },
   [SettingNames.HideInLobbyTooltip] = {
     en = "Shows Ping only in tactical overlay while in Mourningstar",
     ["zh-cn"] = "当处于大厅时，仅在Tab页面显示延迟信息",
-    ["zh-tw"] = "在大廳時僅在Tab頁面顯示延遲資訊",
+    ["zh-tw"] = "位於哀星號時，僅在戰術覆蓋介面顯示延遲資訊",
     ru = "Показывает пинг только в тактическом оверлее пока в лобби",
   },
   [SettingNames.ShowAveragePing] = {
@@ -50,7 +50,7 @@ local localizations = {
   [SettingNames.ShowAveragePingTooltip] = {
     en = "Shows average ping in selected time frame. When disabled, the mod displays last measurement.",
     ["zh-cn"] = "显示选定时间范围内的平均延迟。禁用该选项后，仅显示当前的延迟",
-    ["zh-tw"] = "顯示選定時間範圍內的平均延遲。禁用該選項後，僅顯示當前的延遲",
+    ["zh-tw"] = "顯示所選時間範圍內的平均延遲。停用時，模組會顯示最後一次測量值。",
     ru = "Показывает средний пинг в выбранном временном интервале. При отключении мод отображает последнее измерение.",
   },
   [SettingNames.ShowAveragePingTimeFrame] = {
@@ -62,7 +62,7 @@ local localizations = {
   [SettingNames.PositionOnScreen] = {
     en = "Position on Screen",
     ["zh-cn"] = "设置屏幕上所处的位置",
-    ["zh-tw"] = "設定螢幕上顯示的位置",
+    ["zh-tw"] = "螢幕位置",
     ru = "Положение на экране",
   },
   [SettingNames.CustomHudMode] = {
@@ -86,7 +86,7 @@ local localizations = {
   [SettingNames.CustomHudModeTooltip] = {
     en = "Prevents the mod from updating it's position on the screen, which allows other mods, like Custom HUD, to manage it.",
     ["zh-cn"] = "为防止因MOD更新导致屏幕上所在的位置发生改变，开启此选项可允许由其他MOD管理（例如Custom HUD）",
-    ["zh-tw"] = "防止MOD更新其在螢幕上的位置，允許其他模組（例如 Custom HUD）管理它。",
+    ["zh-tw"] = "防止此模組更新螢幕位置，讓其他模組（例如 Custom HUD）可以管理它。",
     ru = "Предотвращает обновление позиции мода на экране, что позволяет другим модам, таким как Custom HUD, управлять им.",
   },
   [SettingNames.PingXOffset] = {
@@ -104,7 +104,7 @@ local localizations = {
   [SettingNames.PingStyleGroup] = {
     en = "Ping Style Settings",
     ["zh-cn"] = "设置延迟样式",
-    ["zh-tw"] = "設定延遲樣式",
+    ["zh-tw"] = "Ping 樣式設定",
     ru = "Настройки стиля пинга",
   },
   [SettingNames.PingFontSize] = {
@@ -116,7 +116,7 @@ local localizations = {
   [SettingNames.PingLabel] = {
     en = "Label",
     ["zh-cn"] = "文字",
-    ["zh-tw"] = "文字",
+    ["zh-tw"] = "標籤",
     ru = "Обозначение",
   },
   [SettingNames.PingDefaultColor] = {
@@ -146,7 +146,7 @@ local localizations = {
   [SettingNames.PingMiddleColor] = {
     en = "Acceptable Ping Color",
     ["zh-cn"] = "中等延迟颜色",
-    ["zh-tw"] = "中等延遲顏色",
+    ["zh-tw"] = "可接受延遲顏色",
     ru = "Цвет приемлемого пинга",
   },
   [SettingNames.PingHighColor] = {
@@ -158,19 +158,19 @@ local localizations = {
   [SettingNames.PingLowMinValue] = {
     en = "Low Ping Range Start",
     ["zh-cn"] = "低延迟初始值",
-    ["zh-tw"] = "低延遲初始值",
+    ["zh-tw"] = "低延遲範圍起點",
     ru = "Начало диапазона низкого пинга",
   },
   [SettingNames.PingMiddleMinValue] = {
     en = "Acceptable Ping Range Start",
     ["zh-cn"] = "中等延迟初始值",
-    ["zh-tw"] = "中等延遲初始值",
+    ["zh-tw"] = "可接受延遲範圍起點",
     ru = "Начало диапазона приемлемого пинга",
   },
   [SettingNames.PingHighMinValue] = {
     en = "High Ping Range Start",
     ["zh-cn"] = "高延迟初始值",
-    ["zh-tw"] = "高延遲初始值",
+    ["zh-tw"] = "高延遲範圍起點",
     ru = "Начало диапазона высокого пинга",
   },
   [SettingNames.PingLabels.None] = {
@@ -200,7 +200,7 @@ local localizations = {
   [SettingNames.LabelStyleGroup] = {
     en = "Label Style Settings",
     ["zh-cn"] = "设置文字样式",
-    ["zh-tw"] = "設定文字樣式",
+    ["zh-tw"] = "標籤樣式設定",
     ru = "Настройки стиля названия",
   },
   [SettingNames.LabelFontSize] = {
@@ -218,13 +218,13 @@ local localizations = {
   [SettingNames.LabelSidePosition] = {
     en = "Position relative to Ping",
     ["zh-cn"] = "位置",
-    ["zh-tw"] = "位置",
+    ["zh-tw"] = "相對於 Ping 的位置",
     ru = "Позиция относительно пинга",
   },
   [SettingNames.LabelOffsetToPing] = {
     en = "Gap size between Ping",
     ["zh-cn"] = "文字间距",
-    ["zh-tw"] = "文字間距",
+    ["zh-tw"] = "與 Ping 的間距",
     ru = "Расстояние от пинга",
   },
   [SettingNames.LabelYOffset] = {
@@ -236,13 +236,13 @@ local localizations = {
   [SettingNames.LabelUsePingColor] = {
     en = "Match Ping's Color",
     ["zh-cn"] = "参照延迟颜色",
-    ["zh-tw"] = "參照延遲顏色",
+    ["zh-tw"] = "與 Ping 顏色相同",
     ru = "Соответствие цвету пинга",
   },
   [SettingNames.SymbolGroup] = {
     en = "Symbol Style Settings",
     ["zh-cn"] = "设置符号样式",
-    ["zh-tw"] = "設定符號樣式",
+    ["zh-tw"] = "符號樣式設定",
     ru = "Настройки стиля символа",
   },
   [SettingNames.Symbol] = {
@@ -260,7 +260,7 @@ local localizations = {
   [SettingNames.SymbolSidePosition] = {
     en = "Position relative to Ping",
     ["zh-cn"] = "符号位置",
-    ["zh-tw"] = "符號位置",
+    ["zh-tw"] = "相對於 Ping 的位置",
     ru = "Позиция относительно пинга",
   },
   [SettingNames.SymbolColor] = {
@@ -272,7 +272,7 @@ local localizations = {
   [SettingNames.SymbolOffsetToPing] = {
     en = "Gap size between Ping",
     ["zh-cn"] = "间距",
-    ["zh-tw"] = "間距",
+    ["zh-tw"] = "與 Ping 的間距",
     ru = "Расстояние от пинга",
   },
   [SettingNames.SymbolYOffset] = {
@@ -284,7 +284,7 @@ local localizations = {
   [SettingNames.SymbolUsePingColor] = {
     en = "Match Ping's Color",
     ["zh-cn"] = "参照延迟颜色",
-    ["zh-tw"] = "參照延遲顏色",
+    ["zh-tw"] = "與 Ping 顏色相同",
     ru = "Соответствие цвету пинга",
   },
   [SettingNames.SymbolType.Circle] = {
@@ -298,7 +298,7 @@ local localizations = {
     de = "Mitte",
     ru = "Центр",
     ["zh-cn"] = "中部",
-    ["zh-tw"] = "中部",
+    ["zh-tw"] = "中央",
   },
   left = {
     en = "Left",
@@ -319,14 +319,14 @@ local localizations = {
     de = "Oben",
     ru = "Вверху",
     ["zh-cn"] = "上部",
-    ["zh-tw"] = "上部",
+    ["zh-tw"] = "上方",
   },
   bottom = {
     en = "Bottom",
     de = "Unten",
     ru = "Внизу",
     ["zh-cn"] = "下部",
-    ["zh-tw"] = "下部",
+    ["zh-tw"] = "下方",
   },
 }
 
@@ -347,7 +347,8 @@ for i, color_name in ipairs(Color.list) do
   local color_values = Color[color_name](255, true)
   local text = InputUtils.apply_color_to_input_text(color_name_to_readable_text(color_name), color_values)
   localizations[color_name] = {
-    en = text
+    en = text,
+    ["zh-tw"] = text,
   }
 end
 


### PR DESCRIPTION
## Summary
- Correct zh-tw localization for DisplayPing from en source strings
- Align tactical overlay, Mourningstar, label, and Ping color wording
- Add zh-tw assignment for runtime color labels

## Validation
- Checked 54 en assignments and 54 zh-tw assignments
- Confirmed no empty zh-tw values
- Confirmed PR diff contains only DisplayPing_localization.lua