### PR TITLE
Translate zh-tw localization for scoreboard

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/scoreboard/scripts/mods/scoreboard/Scoreboard_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/scoreboard/scripts/mods/scoreboard/Scoreboard_localization.lua
@@ -107,6 +107,7 @@ return {
 		-- de = "Maximale Scoreboardgröße",
 		-- fr = "Taille maximale du tableau de bord", -- ?
 		ru = "Позиция таблицы по горизонтали",
+		["zh-tw"] = "戰術概覽計分板水平位置",
 		-- ["zh-cn"] = "最大记分板高度",
 	},
 	scoreboard_tactical_overlay_y = {
@@ -114,6 +115,7 @@ return {
 		-- de = "Maximale Scoreboardgröße",
 		-- fr = "Taille maximale du tableau de bord", -- ?
 		ru = "Позиция таблицы по вертикали",
+		["zh-tw"] = "戰術概覽計分板垂直位置",
 		-- ["zh-cn"] = "最大记分板高度",
 	},
 	scoreboard_panel_height = {
@@ -792,6 +794,7 @@ return {
 		fr = "Dégâts infligés aux Boss",
 		ru = "Урона нанесено Боссу",
 		["zh-cn"] = "Boss 伤害",
+		["zh-tw"] = "首領傷害",
 	},
 	-- Enemies staggered
 	plugin_enemies_staggerd = {

--- a/Warhammer 40,000 DARKTIDE/mods/scoreboard/scripts/mods/scoreboard/Scoreboard_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/scoreboard/scripts/mods/scoreboard/Scoreboard_localization.lua
@@ -107,7 +107,7 @@ return {
 		-- de = "Maximale Scoreboardgröße",
 		-- fr = "Taille maximale du tableau de bord", -- ?
 		ru = "Позиция таблицы по горизонтали",
-		["zh-tw"] = "戰術概覽計分板水平位置",
+		["zh-tw"] = "計分板水平位置",
 		-- ["zh-cn"] = "最大记分板高度",
 	},
 	scoreboard_tactical_overlay_y = {
@@ -115,7 +115,7 @@ return {
 		-- de = "Maximale Scoreboardgröße",
 		-- fr = "Taille maximale du tableau de bord", -- ?
 		ru = "Позиция таблицы по вертикали",
-		["zh-tw"] = "戰術概覽計分板垂直位置",
+		["zh-tw"] = "計分板垂直位置",
 		-- ["zh-cn"] = "最大记分板高度",
 	},
 	scoreboard_panel_height = {
@@ -794,7 +794,7 @@ return {
 		fr = "Dégâts infligés aux Boss",
 		ru = "Урона нанесено Боссу",
 		["zh-cn"] = "Boss 伤害",
-		["zh-tw"] = "首領傷害",
+		["zh-tw"] = "Boss 傷害",
 	},
 	-- Enemies staggered
 	plugin_enemies_staggerd = {


### PR DESCRIPTION
## Summary
- base branch: main
- head branch: Codex/Feature/scoreboard/Add-zh-tw
- owner: copilot
- completed files:
  - Warhammer 40,000 DARKTIDE/mods/scoreboard/scripts/mods/scoreboard/Scoreboard_localization.lua
- completed key count: 3
- blocked items: none
- Term Candidates.md synced to main: no new candidates

## Notes
- Added missing zh-tw for tactical overlay X/Y position and Boss Damage Dealt.
- PR is ready for review (not draft).