### PR TITLE
Translate zh-tw localization for creature_spawner

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/creature_spawner/scripts/mods/creature_spawner/creature_spawner_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/creature_spawner/scripts/mods/creature_spawner/creature_spawner_localization.lua
@@ -348,13 +348,13 @@ return {
     en = "Keybind: Reset Combat Ability Cooldown",
     ["zh-cn"] = "快捷键：重置主动技能冷却",
     ru = "Клавиша: Cброс времени восстановления боевых способностей",
-    ["zh-tw"] = "快捷鍵：重置戰鬥能力 CD",
+    ["zh-tw"] = "快捷鍵：重置戰鬥技能冷卻",
   },
   cs_reset_combat_ability_cooldown_keybind_description = {
     en = "Choose the keybinding that resets the Combat Ability Cooldown in the Training Grounds.",
     ["zh-cn"] = "选择用于在训练场内重置主动技能冷却的快捷键。",
     ru = "Выберите комбинацию клавиш, которая сбрасывает время восстановления боевых способностей на Стрельбище.",
-    ["zh-tw"] = "選擇用於在訓練場中重置戰鬥能力 CD 的快捷鍵。",
+    ["zh-tw"] = "選擇用於在訓練場中重置戰鬥技能冷卻的快捷鍵。",
   },
   cs_enable_training_grounds_invisibility_keybind = {
     en = "Keybind: Toggle Player Invisibility",


### PR DESCRIPTION
## Summary
- base branch: main
- head branch: Codex/Feature/creature_spawner/Add-zh-tw
- owner: copilot
- completed files:
  - Warhammer 40,000 DARKTIDE/mods/creature_spawner/scripts/mods/creature_spawner/creature_spawner_localization.lua
- completed key count: 2 (terminology corrections)
- blocked items: none
- Term Candidates.md synced to main: no new candidates

## Changes
- cs_reset_combat_ability_cooldown_keybind: 戰鬥能力 CD -> 戰鬥技能冷卻 (Translation.md: Combat Ability -> 戰鬥技能)
- cs_reset_combat_ability_cooldown_keybind_description: same correction

## Notes
- All other zh-tw entries were already correct.
- PR is ready for review (not draft).