### PR TITLE
Translate zh-tw localization for Power_DI

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/Power_DI/scripts/mods/Power_DI/Power_DI_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/Power_DI/scripts/mods/Power_DI/Power_DI_localization.lua
@@ -578,7 +578,7 @@ return {
 	mloc_9_companion = {
 		en = "Companion",
 		--["zh-cn"] = "",
-		["zh-tw"] = "同伴",
+		["zh-tw"] = "電子獒犬",
 	},
 	mloc_chaos_faction = {
 		en = "Chaos",

--- a/Warhammer 40,000 DARKTIDE/mods/Power_DI/scripts/mods/Power_DI/Power_DI_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/Power_DI/scripts/mods/Power_DI/Power_DI_localization.lua
@@ -578,7 +578,7 @@ return {
 	mloc_9_companion = {
 		en = "Companion",
 		--["zh-cn"] = "",
-		--["zh-tw"] = "",
+		["zh-tw"] = "同伴",
 	},
 	mloc_chaos_faction = {
 		en = "Chaos",
@@ -728,7 +728,7 @@ return {
 	mloc_curio = {
 		en = "Curio",
 		["zh-cn"] = "附件",
-		["zh-tw"] = "飾品",
+		["zh-tw"] = "珍品",
 	},
 
 	--Report template value labels
@@ -745,7 +745,7 @@ return {
 	mloc_crit_percent = {
 		en = "Crit percent",
 		["zh-cn"] = "暴击百分比",
-		["zh-tw"] = "暴擊百分比",
+		["zh-tw"] = "致命一擊百分比",
 	},
 	mloc_weakspot_percent = {
 		en = "Weakspot percent",
@@ -881,7 +881,7 @@ return {
 	critical_hit = {
 		en = "Critical hit",
 		["zh-cn"] = "暴击命中",
-		["zh-tw"] = "暴擊命中",
+		["zh-tw"] = "致命一擊",
 	},
 	attacker_faction = {
 		en = "Attacker faction",


### PR DESCRIPTION
## Summary
- base branch: main
- head branch: Codex/Feature/Power_DI/Add-zh-tw
- owner: copilot
- completed files:
  - Warhammer 40,000 DARKTIDE/mods/Power_DI/scripts/mods/Power_DI/Power_DI_localization.lua
- completed key count: 4 (1 missing zh-tw added, 3 terminology corrections)
- blocked items: none
- Term Candidates.md updated: Horde inconsistency noted

## Changes
- mloc_9_companion: added missing zh-tw = 同伴
- mloc_curio: 飾品 -> 珍品 (Translation.md: Curios -> 珍品)
- mloc_crit_percent: 暴擊百分比 -> 致命一擊百分比 (Translation.md: Crit -> 致命一擊)
- critical_hit: 暴擊命中 -> 致命一擊 (Translation.md: Crit -> 致命一擊)

## Notes
- PR is ready for review (not draft).
- mloc_horde 'Horde' translation inconsistency between Power_DI (成群小怪) and CombatStats (屍潮) noted in Term Candidates.md.