### PR TITLE
Translate zh-tw localization for NumericUI

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/NumericUI/scripts/mods/NumericUI/NumericUI_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/NumericUI/scripts/mods/NumericUI/NumericUI_localization.lua
@@ -107,7 +107,7 @@ local loc = {
 	peril_icon = {
 		en = "Show peril icon",
 		["zh-cn"] = "显示危机值图标",
-		["zh-tw"] = "顯示危機值圖示",
+		["zh-tw"] = "顯示反噬圖示",
 		ru = "Показывать значок опасности",
 		fr = "Affiche l'icône du péril",
 	},


### PR DESCRIPTION
## Summary
- base branch: main
- head branch: Codex/Feature/NumericUI/Add-zh-tw
- owner: copilot
- completed files: NumericUI_localization.lua
- completed key count: 1 (terminology correction)

## Changes
- peril_icon: 顯示危機值圖示 -> 顯示反噬圖示 (Translation.md: Peril -> 反噬)

## Notes
- PR is ready for review.