### PR TITLE
Translate zh-tw localization for EmpowerUntilLimit

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/EmpowerUntilLimit/scripts/mods/EmpowerUntilLimit/EmpowerUntilLimit_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/EmpowerUntilLimit/scripts/mods/EmpowerUntilLimit/EmpowerUntilLimit_localization.lua
@@ -1,6 +1,7 @@
 return {
     mod_name = {
         en = "Empower Until Limit",
+        ["zh-tw"] = "強化至上限",
         ["zh-cn"] = "强化到顶",
         ["zh-cn"] = "武器自動强化",
         ru = "Усиление до предела",
@@ -9,7 +10,7 @@ return {
         en = "Keep empowering the weapon quickly until reaching the limit.",
         ja = "限界に達するまで素早く武器を強化し続けます。",
         ["zh-cn"] = "快速强化武器，直到达到限制。",
-        ["zh-tw"] = "快速強化武器，直到上限。",
+        ["zh-tw"] = "持續快速強化武器，直到達到上限。",
         ru = "Empower Until Limit - Продолжает быстро усиливать оружие, пока оно не достигнет предела.",
     },
 }

--- a/Warhammer 40,000 DARKTIDE/mods/EmpowerUntilLimit/scripts/mods/EmpowerUntilLimit/EmpowerUntilLimit_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/EmpowerUntilLimit/scripts/mods/EmpowerUntilLimit/EmpowerUntilLimit_localization.lua
@@ -10,7 +10,7 @@ return {
         en = "Keep empowering the weapon quickly until reaching the limit.",
         ja = "限界に達するまで素早く武器を強化し続けます。",
         ["zh-cn"] = "快速强化武器，直到达到限制。",
-        ["zh-tw"] = "持續快速強化武器，直到達到上限。",
+        ["zh-tw"] = "自動強化武器，直到達到上限。",
         ru = "Empower Until Limit - Продолжает быстро усиливать оружие, пока оно не достигнет предела.",
     },
 }


### PR DESCRIPTION
Base: main
Head: Codex/Feature/EmpowerUntilLimit/Add-zh-tw
AI handler: codex
Submitter display name: SyuanTsai

Completed files:
- Warhammer 40,000 DARKTIDE/mods/EmpowerUntilLimit/scripts/mods/EmpowerUntilLimit/EmpowerUntilLimit_localization.lua

Completed key count: 2
- mod_name: added zh-tw
- mod_description: corrected zh-tw wording

Blocked items: none for this PR. Previous identity blocker BLOCKER-0001 is resolved because GitHub display name now returns SyuanTsai.

Term candidates updated: yes, Empower -> 強化.

Validation:
- Verified PR diff only includes EmpowerUntilLimit_localization.lua.
- Checked zh-tw fields are present once per English key.
- Checked no empty zh-tw values.
- Lua CLI is not installed locally, so Lua syntax validation was not run.