### PR TITLE
Translate zh-tw localization for ErrorTracker

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/ErrorTracker/scripts/mods/ErrorTracker/ErrorTracker_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/ErrorTracker/scripts/mods/ErrorTracker/ErrorTracker_localization.lua
@@ -5,6 +5,6 @@ return {
     },
     mod_description = {
         en = "{#color(255,0,0)}Detects mod crashes, prints clear reports, and saves them to files.{#reset()}",
-        ["zh-tw"] = "{#color(255,0,0)}偵測 MOD 崩潰，輸出清楚報告並儲存成檔案。{#reset()}",
+        ["zh-tw"] = "{#color(255,0,0)}偵測 MOD 崩潰，輸出清楚的報告並儲存成檔案。{#reset()}",
     },
 }

--- a/Warhammer 40,000 DARKTIDE/mods/ErrorTracker/scripts/mods/ErrorTracker/ErrorTracker_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/ErrorTracker/scripts/mods/ErrorTracker/ErrorTracker_localization.lua
@@ -5,6 +5,6 @@ return {
     },
     mod_description = {
         en = "{#color(255,0,0)}Detects mod crashes, prints clear reports, and saves them to files.{#reset()}",
-        ["zh-tw"] = "{#color(255,0,0)}偵測模組崩潰，輸出清楚的報告，並儲存為檔案。{#reset()}",
+        ["zh-tw"] = "{#color(255,0,0)}偵測 MOD 崩潰，輸出清楚報告並儲存成檔案。{#reset()}",
     },
 }


### PR DESCRIPTION
Base: main
Head: Codex/Feature/ErrorTracker/Add-zh-tw
AI handler: codex

Completed files:
- Warhammer 40,000 DARKTIDE/mods/ErrorTracker/scripts/mods/ErrorTracker/ErrorTracker_localization.lua

Completed keys: 1 zh-tw correction
- Clarifies mod crash report description and uses MOD consistently.
- Preserves color formatting tokens.

Blocked items: none
Term candidates updated: no
Checks: en=2, zh-tw=2, empty zh-tw=0, placeholder scan=no placeholders, diff scope ok.