### PR TITLE
Translate zh-tw localization for KeepSwinging

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/KeepSwinging/scripts/mods/KeepSwinging/KeepSwinging_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/KeepSwinging/scripts/mods/KeepSwinging/KeepSwinging_localization.lua
@@ -7,27 +7,27 @@ return {
 	held_keybind = {
 		en = "Enable Auto-Swing (Held)",
 		["zh-cn"] = "启用自动攻击（按住）",
-		["zh-tw"] = "啟用自動揮擊（按住）",
+		["zh-tw"] = "啟用自動攻擊（按住）",
 	},
 	pressed_keybind = {
 		en = "Enable Auto-Swing (Toggle)",
 		["zh-cn"] = "启用自动攻击（切换）",
-		["zh-tw"] = "啟用自動揮擊（切換）",
+		["zh-tw"] = "啟用自動攻擊（切換）",
 	},
 	as_modifier = {
 		en = "Modifier Mode",
 		["zh-cn"] = "修改模式",
-		["zh-tw"] = "攻擊鍵修飾模式",
+		["zh-tw"] = "啟動自動輕攻擊按鈕",
 	},
 	as_modifier_description = {
 		en = "If ON, Auto-Swing will modify your normal attack button to spam light attacks instead of performing heavy attacks. If OFF, Auto-Swing will perform light attacks for you without having to press the attack button.",
 		["zh-cn"] = "启用时，你的默认攻击键将重复轻攻击而不再重攻击。禁用时，无需按下攻击键，就会执行自动轻攻击。",
-		["zh-tw"] = "開啟時，自動揮擊會改變一般攻擊按鈕，使其連續發動輕攻擊而非重攻擊。關閉時，無需按下攻擊按鈕，自動揮擊也會替你執行輕攻擊。",
+		["zh-tw"] = "開啟時，自動攻擊會改變一般攻擊按鈕，使其連續發動輕攻擊而非重攻擊。關閉時，無需按下攻擊按鈕，自動攻擊也會替你執行輕攻擊。",
 	},
 	group_disable_acts = {
 		en = "Manual Actions Interrupt Auto-Swing",
 		["zh-cn"] = "手动操作打断自动攻击",
-		["zh-tw"] = "手動操作中斷自動揮擊",
+		["zh-tw"] = "手動操作中斷自動攻擊",
 	},
 	persist_after_disable = {
 		en = "Temporary Interruption",
@@ -37,7 +37,7 @@ return {
 	persist_after_disable_description = {
 		en = "If ON, Auto-Swing resumes when the interrupting action is finished. If OFF, Auto-Swing is toggled off when an interrupting action starts.",
 		["zh-cn"] = "启用时，打断动作结束后恢复自动攻击。禁用时，打断动作开始时关闭自动攻击。",
-		["zh-tw"] = "開啟時，中斷動作結束後會恢復自動揮擊。關閉時，中斷動作開始時會關閉自動揮擊。",
+		["zh-tw"] = "開啟時，中斷動作結束後會恢復自動攻擊。關閉時，中斷動作開始時會關閉自動攻擊。",
 	},
 	disable_action_one_hold = {
 		en = "Attack",
@@ -62,7 +62,7 @@ return {
 	default_mode = {
 		en = "Default to Auto-Swing",
 		["zh-cn"] = "默认自动攻击",
-		["zh-tw"] = "預設啟用自動揮擊",
+		["zh-tw"] = "預設啟用自動攻擊",
 	},
 	hud_element = {
 		en = "HUD Indicator",
@@ -77,7 +77,7 @@ return {
 	group_select = {
 		en = "Auto-Swinging",
 		["zh-cn"] = "自动攻击",
-		["zh-tw"] = "自動揮擊",
+		["zh-tw"] = "自動攻擊",
 	},
 	group_extra = {
 		en = "Misc",

--- a/Warhammer 40,000 DARKTIDE/mods/KeepSwinging/scripts/mods/KeepSwinging/KeepSwinging_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/KeepSwinging/scripts/mods/KeepSwinging/KeepSwinging_localization.lua
@@ -2,7 +2,7 @@ return {
 	mod_description = {
 		en = "Adds keybinds to spam light melee attacks for you.",
 		["zh-cn"] = "设置快捷键自动重复近战武器轻攻击。",
-		["zh-tw"] = "新增快捷鍵來替你自動重複輕型近戰攻擊。",
+		["zh-tw"] = "新增快捷鍵，替你自動連續發動近戰輕攻擊。",
 	},
 	held_keybind = {
 		en = "Enable Auto-Swing (Held)",
@@ -17,12 +17,12 @@ return {
 	as_modifier = {
 		en = "Modifier Mode",
 		["zh-cn"] = "修改模式",
-		["zh-tw"] = "修飾模式",
+		["zh-tw"] = "攻擊鍵修飾模式",
 	},
 	as_modifier_description = {
 		en = "If ON, Auto-Swing will modify your normal attack button to spam light attacks instead of performing heavy attacks. If OFF, Auto-Swing will perform light attacks for you without having to press the attack button.",
 		["zh-cn"] = "启用时，你的默认攻击键将重复轻攻击而不再重攻击。禁用时，无需按下攻击键，就会执行自动轻攻击。",
-		["zh-tw"] = "開啟時，你的一般攻擊按鈕將連續發動輕型攻擊而非重型攻擊。關閉時，自動揮擊將替你執行輕型攻擊，無需按下攻擊按鈕。",
+		["zh-tw"] = "開啟時，自動揮擊會改變一般攻擊按鈕，使其連續發動輕攻擊而非重攻擊。關閉時，無需按下攻擊按鈕，自動揮擊也會替你執行輕攻擊。",
 	},
 	group_disable_acts = {
 		en = "Manual Actions Interrupt Auto-Swing",
@@ -57,17 +57,17 @@ return {
 	disable_weapon_extra_hold = {
 		en = "Weapon Extra",
 		["zh-cn"] = "武器特殊",
-		["zh-tw"] = "武器特殊功能",
+		["zh-tw"] = "武器特殊動作",
 	},
 	default_mode = {
 		en = "Default to Auto-Swing",
 		["zh-cn"] = "默认自动攻击",
-		["zh-tw"] = "預設為自動揮擊",
+		["zh-tw"] = "預設啟用自動揮擊",
 	},
 	hud_element = {
 		en = "HUD Indicator",
 		["zh-cn"] = "HUD 指示器",
-		["zh-tw"] = "介面指示器",
+		["zh-tw"] = "HUD 指示器",
 	},
 	hud_element_size = {
 		en = "Indicator Size",
@@ -82,7 +82,7 @@ return {
 	group_extra = {
 		en = "Misc",
 		["zh-cn"] = "杂项",
-		["zh-tw"] = "其他設定",
+		["zh-tw"] = "雜項",
 	},
 	group_attack_types = {
 		en = "Attack Types",


### PR DESCRIPTION
## Summary
- Refine Auto-Swing Traditional Chinese wording for KeepSwinging
- Clarify Modifier Mode as attack-button modifier mode
- Align HUD, weapon extra, default mode, and misc labels with concise UI phrasing

## Checks
- Diff scope: KeepSwinging_localization.lua only
- zh-tw fields: 18
- Empty zh-tw values: 0
- Placeholder/token scan: no placeholders
- Dynamic Localize entries: 4 intentionally left without hard-coded zh-tw
- git diff --check: no whitespace errors beyond existing LF/CRLF warning