### PR TITLE
Translate zh-tw localization for KPM

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/KPM/scripts/mods/KPM/KPM_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/KPM/scripts/mods/KPM/KPM_localization.lua
@@ -5,18 +5,18 @@ return {
 	},
 	mod_description = {
 		en = "[Warhammer 40K Darktide Competition Mod] Displays team KPM data - Custom development: deluxghost",
-		["zh-tw"] = "[戰鎚40K暗潮吧競賽模組] 顯示全隊 KPM 數據 - 客製化開發：deluxghost",
+		["zh-tw"] = "[戰錘40K黑潮競賽模組] 顯示團隊 KPM 資料 - 客製化開發：deluxghost",
 	},
 	show_mkpm = {
 		en = "Show Melee Elite KPM",
-		["zh-tw"] = "顯示近戰精英 KPM",
+		["zh-tw"] = "顯示近戰類精英 KPM",
 	},
 	show_rkpm = {
 		en = "Show Ranged Elite KPM",
-		["zh-tw"] = "顯示遠程精英 KPM",
+		["zh-tw"] = "顯示遠程類精英 KPM",
 	},
 	show_skpm = {
 		en = "Show Specialist KPM",
-		["zh-tw"] = "顯示專家 KPM",
+		["zh-tw"] = "顯示專家敵人 KPM",
 	},
 }

--- a/Warhammer 40,000 DARKTIDE/mods/KPM/scripts/mods/KPM/KPM_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/KPM/scripts/mods/KPM/KPM_localization.lua
@@ -5,7 +5,7 @@ return {
 	},
 	mod_description = {
 		en = "[Warhammer 40K Darktide Competition Mod] Displays team KPM data - Custom development: deluxghost",
-		["zh-tw"] = "[戰錘40K黑潮競賽模組] 顯示團隊 KPM 資料 - 客製化開發：deluxghost",
+		["zh-tw"] = "顯示團隊 KPM 資料 - 客製化開發：deluxghost",
 	},
 	show_mkpm = {
 		en = "Show Melee Elite KPM",


### PR DESCRIPTION
## Summary
- Refine KPM Traditional Chinese description with glossary-aligned Darktide wording
- Clarify melee/ranged elite KPM category labels
- Use Specialist as 專家敵人 per glossary

## Checks
- Diff scope: KPM_localization.lua only
- en fields: 5
- zh-tw fields: 5
- Empty zh-tw values: 0
- Placeholder/token scan: no placeholders
- git diff --check: no whitespace errors beyond existing LF/CRLF warning