### PR TITLE
fix: improve zh-tw scoreboard explosive localization

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/ScoreboardExplosive/scripts/mods/ScoreboardExplosive/ScoreboardExplosive_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/ScoreboardExplosive/scripts/mods/ScoreboardExplosive/ScoreboardExplosive_localization.lua
@@ -2,56 +2,56 @@ return {
 	mod_name = {
 		en = "Scoreboard Explosive",
         ["zh-cn"] = "记分板爆炸物统计",
-		["zh-tw"] = "記分板 - 爆桶統計",
+		["zh-tw"] = "Scoreboard 爆炸物統計",
 	},
 	mod_description = {
 		en = "Add explosive stats to scoreboard mod.",
         ["zh-cn"] = "为记分板模组添加爆炸物数据。",
-		["zh-tw"] = "為記分板模組添加爆桶資料。",
+		["zh-tw"] = "在 Scoreboard 模組新增爆炸物統計。",
 	},
 	option_explosive_ignited = {
 		en = "Enable explosive ignited stats",
         ["zh-cn"] = "启用点燃爆炸物统计",
-		["zh-tw"] = "啟用點燃爆桶統計",
+		["zh-tw"] = "啟用點燃爆炸物統計",
 	},
 	option_message_explosive_ignited = {
 		en = "Show explosive ignited message",
         ["zh-cn"] = "显示点燃爆炸物消息",
-		["zh-tw"] = "顯示點燃爆桶消息",
+		["zh-tw"] = "顯示點燃爆炸物訊息",
 	},
 	option_message_explosive_detonated = {
 		en = "Show explosive detonated message",
         ["zh-cn"] = "显示引爆爆炸物消息",
-		["zh-tw"] = "顯示引爆爆桶消息",
+		["zh-tw"] = "顯示引爆爆炸物訊息",
 	},
 	explosive_ignited = {
 		en = "Explosive ignited",
         ["zh-cn"] = "点燃爆炸物",
-		["zh-tw"] = "點燃爆桶",
+		["zh-tw"] = "點燃爆炸物",
 	},
 	explosive_common = {
 		en = "Explosive",
         ["zh-cn"] = "爆炸物",
-		["zh-tw"] = "爆桶",
+		["zh-tw"] = "爆炸物",
 	},
 	explosive_fire_barrel = {
 		en = "Fire Barrel",
         ["zh-cn"] = "燃料桶",
-		["zh-tw"] = "燃料桶",
+		["zh-tw"] = "火焰桶",
 	},
 	explosive_explosion_barrel = {
 		en = "Explosion Barrel",
         ["zh-cn"] = "炸药桶",
-		["zh-tw"] = "炸藥桶",
+		["zh-tw"] = "爆炸桶",
 	},
 	message_explosive_ignited = {
 		en = " ignited :explosive:",
         ["zh-cn"] = "点燃了:explosive:",
-		["zh-tw"] = "點燃了:explosive:",
+		["zh-tw"] = " 點燃了 :explosive:",
 	},
 	message_explosive_detonated = {
 		en = " detonated :explosive:",
         ["zh-cn"] = "引爆了:explosive:",
-		["zh-tw"] = "引爆了:explosive:",
+		["zh-tw"] = " 引爆了 :explosive:",
 	},
 }

--- a/Warhammer 40,000 DARKTIDE/mods/ScoreboardExplosive/scripts/mods/ScoreboardExplosive/ScoreboardExplosive_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/ScoreboardExplosive/scripts/mods/ScoreboardExplosive/ScoreboardExplosive_localization.lua
@@ -2,42 +2,41 @@ return {
 	mod_name = {
 		en = "Scoreboard Explosive",
         ["zh-cn"] = "记分板爆炸物统计",
-		["zh-tw"] = "Scoreboard 爆炸物統計",
+		["zh-tw"] = "記分板爆炸桶統計",
 	},
 	mod_description = {
 		en = "Add explosive stats to scoreboard mod.",
         ["zh-cn"] = "为记分板模组添加爆炸物数据。",
-		["zh-tw"] = "在 Scoreboard 模組新增爆炸物統計。",
+		["zh-tw"] = "在記分板模組新增爆炸桶統計。",
 	},
 	option_explosive_ignited = {
 		en = "Enable explosive ignited stats",
         ["zh-cn"] = "启用点燃爆炸物统计",
-		["zh-tw"] = "啟用點燃爆炸物統計",
+		["zh-tw"] = "啟用點燃爆炸桶統計",
 	},
 	option_message_explosive_ignited = {
 		en = "Show explosive ignited message",
         ["zh-cn"] = "显示点燃爆炸物消息",
-		["zh-tw"] = "顯示點燃爆炸物訊息",
+		["zh-tw"] = "顯示點燃爆炸桶訊息",
 	},
 	option_message_explosive_detonated = {
 		en = "Show explosive detonated message",
         ["zh-cn"] = "显示引爆爆炸物消息",
-		["zh-tw"] = "顯示引爆爆炸物訊息",
+		["zh-tw"] = "顯示引爆爆炸桶訊息",
 	},
 	explosive_ignited = {
 		en = "Explosive ignited",
         ["zh-cn"] = "点燃爆炸物",
-		["zh-tw"] = "點燃爆炸物",
+		["zh-tw"] = "點燃爆炸桶",
 	},
 	explosive_common = {
 		en = "Explosive",
-        ["zh-cn"] = "爆炸物",
-		["zh-tw"] = "爆炸物",
+		["zh-tw"] = "爆炸桶",
 	},
 	explosive_fire_barrel = {
 		en = "Fire Barrel",
         ["zh-cn"] = "燃料桶",
-		["zh-tw"] = "火焰桶",
+		["zh-tw"] = "燃燒桶",
 	},
 	explosive_explosion_barrel = {
 		en = "Explosion Barrel",


### PR DESCRIPTION
## Summary
- Correct zh-tw labels for Scoreboard Explosive settings and messages
- Use consistent explosive/barrel wording and Traditional Chinese UI terms
- Preserve message placeholders while improving combat-feed spacing

## Checks
- git diff --check
- zh-tw active entries: 11; active empty zh-tw: 0; duplicate zh-tw per block: 0
- PR diff scope: localization file only