### PR TITLE
Translate zh-tw localization for i_wanna_see

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/i_wanna_see/scripts/mods/i_wanna_see/i_wanna_see_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/i_wanna_see/scripts/mods/i_wanna_see/i_wanna_see_localization.lua
@@ -6,7 +6,7 @@ return {
 	},
 	mod_description = {
 		en = "Remove sources of VFX that block vision",
-		["zh-tw"] = "移除阻擋視線的特效",
+		["zh-tw"] = "移除阻擋視線的特效來源",
 	},
 	remove_purgatus_effect = {
 		en = "Remove Inferno Staff Effects",
@@ -14,11 +14,11 @@ return {
 	},
 	remove_flamer_effect = {
 		en = "Remove Zealot Flamer Effects",
-		["zh-tw"] = "移除狂信徒火焰噴射器特效",
+		["zh-tw"] = "移除狂信徒淨化噴火器特效",
 	},
 	remove_smite_effect = {
 		en = "Remove Smite Lightning Effects",
-		["zh-tw"] = "移除懲戒特效",
+		["zh-tw"] = "移除懲戒閃電特效",
 	},
 	remove_electro_effect = {
 		en = "Remove Electro Staff Lightning Effects",


### PR DESCRIPTION
## Summary
- AI handler: codex
- Base: main
- Head: Codex/Feature/i_wanna_see/Add-zh-tw
- Completed file: `Warhammer 40,000 DARKTIDE/mods/i_wanna_see/scripts/mods/i_wanna_see/i_wanna_see_localization.lua`
- Corrected 3 zh-tw localization entries for VFX source wording, Zealot Flamer terminology, and Smite Lightning wording.

## Checks
- `git diff --check`
- localization structure scan: tables=13, duplicate zh-tw=0, empty zh-tw=0, placeholder mismatch=0
- diff scope: only target localization file
- Lua syntax tool unavailable locally

## Blocked
- None

## Term candidates
- None