### PR TITLE
Translate zh-tw localization for CombatStats

### DIFF
--- a/Warhammer 40,000 DARKTIDE/mods/CombatStats/scripts/mods/CombatStats/CombatStats_localization.lua
+++ b/Warhammer 40,000 DARKTIDE/mods/CombatStats/scripts/mods/CombatStats/CombatStats_localization.lua
@@ -290,7 +290,7 @@ return {
     breed_horde = {
         en = 'horde',
         ['zh-cn'] = '尸潮',
-        ['zh-tw'] = '屍潮',
+        ['zh-tw'] = '群怪',
     },
     breed_unknown = {
         en = 'unknown',


### PR DESCRIPTION
Base: main
Head: Codex/Feature/CombatStats/Add-zh-tw
AI handler: codex

Completed files:
- Warhammer 40,000 DARKTIDE/mods/CombatStats/scripts/mods/CombatStats/CombatStats_localization.lua

Completed keys: 1 corrected
- breed_horde: align Horde with glossary translation 群怪

Blocked items: none
Term candidates updated: no

Checks:
- duplicate zh-tw=0
- empty zh-tw=0
- en entries=57, zh-tw entries=57
- placeholder risk checked; no placeholders in changed string
- git diff --check passed
- Lua syntax tool unavailable locally